### PR TITLE
Fix: Ensure OpenAI API key is correctly used by me

### DIFF
--- a/order_agent.py
+++ b/order_agent.py
@@ -65,6 +65,8 @@ class OrderAgent:
         ]
 
     def _openai_chat(self, messages: list[dict[str, str]]) -> dict[str, Any]:
+        if not openai.api_key:
+            return {"choices": [{"message": {"content": "(OpenAI API key not set in agent)"}}]}
         if openai is None:
             raise RuntimeError("openai package is not installed")
         return openai.ChatCompletion.create(

--- a/web_server.py
+++ b/web_server.py
@@ -44,14 +44,11 @@ def chat():
         {"role": "user", "content": msg},
     ]
 
-    if (os.getenv("OPENAI_API_KEY") or os.getenv("RAILWAY_OPENAI_KEY")) and agent:
-        try:
-            response = agent._openai_chat(messages)
-            reply = response["choices"][0]["message"].get("content", "")
-        except Exception as exc:  # pragma: no cover - runtime safety
-            reply = f"Error: {exc}"
-    else:
-        reply = "(OpenAI not configured)"
+    try:
+        response = agent._openai_chat(messages)
+        reply = response["choices"][0]["message"].get("content", "")
+    except Exception as exc:  # pragma: no cover - runtime safety
+        reply = f"Error: {exc}"
     return jsonify({"reply": reply})
 
 


### PR DESCRIPTION
The web server was performing a redundant check for the OpenAI API key environment variables within the /chat request handler. This could lead to the key not being recognized even if it was available during application startup.

This commit centralizes the API key handling:
1.  My internal process for handling OpenAI chat now checks if an API key is set. If not, it returns a specific message: `(OpenAI API key not set in agent)`.
2.  The web server's `/chat` handler now unconditionally calls my internal chat process and relies on my response to determine if the key is configured, removing the redundant environment variable check.

This ensures that if the `RAILWAY_OPENAI_KEY` (or `OPENAI_API_KEY`) is correctly set as an environment variable, it will be picked up when I am initialized, and its status will be accurately reflected during chat operations.